### PR TITLE
Start collectd on runlevel 2 (which Ubuntu defaults to) in addition to 3...

### DIFF
--- a/templates/default/collectd.upstart.conf.erb
+++ b/templates/default/collectd.upstart.conf.erb
@@ -1,6 +1,6 @@
 description "collectd"
 
-start on runlevel [345]
+start on runlevel [2345]
 stop on runlevel [s016]
 respawn
 expect fork


### PR DESCRIPTION
I am testing on Ubuntu 12.04, which I just learned boots to runlevel 2 by default, and collectd wasn't being started after a reboot.  Simple fix to add runlevel 2.
